### PR TITLE
Add an initial health endpoint

### DIFF
--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -177,6 +177,9 @@ func SetupRouter(interceptor ServiceBrokerInterceptor, routerConfig RouterConfig
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: routerConfig.SkipVerifyTLS},
 	}
 	client := osbProxy{routerConfig.HttpClientFactory(tr), interceptor, routerConfig}
+	mux.GET("/health", func(ctx *gin.Context) {
+		ctx.Status(http.StatusOK)
+	})
 	if interceptor.HasAdaptCredentials() {
 		mux.POST("/v2/service_instances/:instance_id/service_bindings/:binding_id/adapt_credentials", client.updateCredentials)
 	}

--- a/pkg/router/router_test.go
+++ b/pkg/router/router_test.go
@@ -14,6 +14,20 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+func TestHealthEndpoint(t *testing.T) {
+	g := NewGomegaWithT(t)
+	router := SetupRouter(NoOpInterceptor{}, RouterConfig{})
+
+	emptyBody := bytes.NewReader([]byte(""))
+	request, _ := http.NewRequest(http.MethodGet, "https://blablub.org/health", emptyBody)
+	response := httptest.NewRecorder()
+
+	router.ServeHTTP(response, request)
+	code := response.Code
+
+	g.Expect(code).To(Equal(http.StatusOK))
+}
+
 func TestInvalidUpdateCredentials(t *testing.T) {
 	g := NewGomegaWithT(t)
 	router := SetupRouter(ProducerInterceptor{ProviderId: "x"}, RouterConfig{})


### PR DESCRIPTION
This will allow an external monitoring system to check if the
broker can be accessed.

This can be extended to report detailed health information.
